### PR TITLE
Search devices through SSDP, add basic support to Wemo Insight

### DIFF
--- a/lib/wemote.rb
+++ b/lib/wemote.rb
@@ -2,7 +2,9 @@ require_relative './wemote/version'
 
 module Wemote
   require_relative './wemote/collection/switch'
+  require_relative './wemote/collection/insight'
   require_relative './wemote/switch'
+  require_relative './wemote/insight'
   require_relative './wemote/client'
   require_relative './wemote/xml'
 

--- a/lib/wemote/collection/insight.rb
+++ b/lib/wemote/collection/insight.rb
@@ -1,0 +1,12 @@
+module Wemote
+  module Collection
+
+    # This class provides an extension on the basic Array object, in order to
+    # facilitate group operations on a collection of Wemote::Switch instances.
+    class Insight < Switch
+
+      make :standby?
+
+    end
+  end
+end

--- a/lib/wemote/insight.rb
+++ b/lib/wemote/insight.rb
@@ -1,0 +1,90 @@
+require 'socket'
+require 'ipaddr'
+require 'timeout'
+
+module Wemote
+
+  # This class encapsulates an individual Wemo Insight. It provides methods for
+  # getting and setting the insight's state, as well as a {#toggle!} method for
+  # convenience. Finally, it provides the {#poll} method, which accepts a block
+  # to be executed any time the insight changes state.
+  class Insight < Switch
+
+    GET_HEADERS_POWER = {
+      "SOAPACTION"   => '"urn:Belkin:service:insight:1#GetInsightParams"',
+      "Content-type" => 'text/xml; charset="utf-8"'
+    }
+
+    class << self
+
+      def device_type
+        'urn:Belkin:device:insight:1'
+      end
+
+      # Returns all Insight detected on the local network
+      #
+      # @param [Boolean] refresh Refresh and redetect Insight
+      # @return [Array] all Insight on the network
+      def all(refresh=false)
+        @insights = nil if refresh
+        @insights ||= Wemote::Collection::Insight.new(discover)
+      end
+
+    end
+
+    def initialize(host,port=nil)
+      super(host, port)
+    end
+
+    # Turn the Insight on or off, based on its current state
+    def toggle!  
+      on? or standby? ? off! : on!;   
+    end
+
+    # Return whether the Insight is standby
+    #
+    # @return [Boolean]
+    def standby?
+      get_state == :standby;   
+    end
+
+    def power
+      get_insight_params()[:power]
+    end
+
+    private
+
+    def get_state
+      response = begin
+        client.post("http://#{@host}:#{@port}/upnp/control/basicevent1",Wemote::XML.get_binary_state,GET_HEADERS)
+      rescue Exception
+        client.post("http://#{@host}:#{@port}/upnp/control/basicevent1",Wemote::XML.get_binary_state,GET_HEADERS)
+      end
+      case response.body.match(/<BinaryState>(\d)<\/BinaryState>/)[1]
+        when '0'
+          :off
+        when '1'
+          :on
+        when '8'
+          :standby
+      end
+    end
+
+    def get_insight_params
+      response = begin
+        client.post("http://#{@host}:#{@port}/upnp/control/insight1",Wemote::XML.get_insight_params,GET_HEADERS_POWER)
+      rescue Exception
+        client.post("http://#{@host}:#{@port}/upnp/control/insight1",Wemote::XML.get_insight_params,GET_HEADERS_POWER)
+      end
+      params = response.body.match(/<InsightParams>(.*)<\/InsightParams>/)[1].split('|')
+      {
+        value: (params[0].to_i == 0 ? :off : :on),
+        energy: (params[8].to_i / 60000000.0).ceil,
+        power: (params[7].to_i / 1000.0).round,
+        on_today: (params[3].to_i / 60.0).floor
+      }      
+    end
+
+
+  end
+end

--- a/lib/wemote/insight.rb
+++ b/lib/wemote/insight.rb
@@ -1,6 +1,7 @@
 require 'socket'
 require 'ipaddr'
 require 'timeout'
+require 'ssdp'
 
 module Wemote
 
@@ -32,10 +33,6 @@ module Wemote
 
     end
 
-    def initialize(host,port=nil)
-      super(host, port)
-    end
-
     # Turn the Insight on or off, based on its current state
     def toggle!  
       on? or standby? ? off! : on!;   
@@ -52,15 +49,18 @@ module Wemote
       get_insight_params()[:power]
     end
 
+    def energy
+      get_insight_params()[:energy]
+    end
+
+    def on_today
+      get_insight_params()[:on_today]
+    end
+
     private
 
     def get_state
-      response = begin
-        client.post("http://#{@host}:#{@port}/upnp/control/basicevent1",Wemote::XML.get_binary_state,GET_HEADERS)
-      rescue Exception
-        client.post("http://#{@host}:#{@port}/upnp/control/basicevent1",Wemote::XML.get_binary_state,GET_HEADERS)
-      end
-      case response.body.match(/<BinaryState>(\d)<\/BinaryState>/)[1]
+      case get_binary_state()
         when '0'
           :off
         when '1'

--- a/lib/wemote/switch.rb
+++ b/lib/wemote/switch.rb
@@ -1,6 +1,7 @@
 require 'socket'
 require 'ipaddr'
 require 'timeout'
+require 'ssdp'
 
 module Wemote
 
@@ -132,12 +133,16 @@ module Wemote
     protected
 
     def get_state
+      self.get_binary_state() == '1' ? :on : :off
+    end
+
+    def get_binary_state
       response = begin
         client.post("http://#{@host}:#{@port}/upnp/control/basicevent1",Wemote::XML.get_binary_state,GET_HEADERS)
       rescue Exception
         client.post("http://#{@host}:#{@port}/upnp/control/basicevent1",Wemote::XML.get_binary_state,GET_HEADERS)
       end
-      response.body.match(/<BinaryState>(\d)<\/BinaryState>/)[1] == '1' ? :on : :off
+      response.body.match(/<BinaryState>(\d)<\/BinaryState>/)[1]
     end
 
     def set_state(state)

--- a/lib/wemote/switch.rb
+++ b/lib/wemote/switch.rb
@@ -10,8 +10,6 @@ module Wemote
   # to be executed any time the switch changes state.
   class Switch
 
-    GOOGLE_IP = "64.233.187.99"
-
     GET_HEADERS = {
       "SOAPACTION"   => '"urn:Belkin:service:basicevent:1#GetBinaryState"',
       "Content-type" => 'text/xml; charset="utf-8"'
@@ -23,6 +21,11 @@ module Wemote
     }
 
     class << self
+
+      def device_type
+        'urn:Belkin:device:controllee:1'
+      end
+
       # Returns all Switches detected on the local network
       #
       # @param [Boolean] refresh Refresh and redetect Switches
@@ -40,41 +43,55 @@ module Wemote
         all.detect{|s|s.name == name}
       end
 
-      private
+      protected
 
       def discover
-        ip = UDPSocket.open {|s| s.connect(GOOGLE_IP, 1); s.addr.last}
-        `nmap -sP #{ip.split('.')[0..-2].join('.')}.* > /dev/null && arp -na | grep b4:75`.split("\n").map do |device|
-          self.new(/\((\d+\.\d+\.\d+\.\d+)\)/.match(device)[1])
-        end.reject{|device| device.instance_variable_get(:@port).nil? }
+        finder = SSDP::Consumer.new timeout: 3, first_only: false
+        finder.search(service: self.device_type).map do |device|
+          self.new(device[:address], device[:params]['LOCATION'].match(/:([0-9]{1,5})\//)[1])
+        end
       end
+
     end
 
     attr_accessor :name
 
     def initialize(host,port=nil)
       @host, @port = host, port
-      set_meta
+    end
+
+    def device_type 
+      'urn:Belkin:device:controllee:1'
     end
 
     # Turn the Switch on or off, based on its current state
-    def toggle!;  on? ? off! : on!;   end
+    def toggle!
+        on? ? off! : on!
+    end
 
     # Turn the Switch off
-    def off!;     set_state(0);       end
+    def off!     
+      set_state(0)       
+    end
 
     # Turn the Switch on
-    def on!;      set_state(1);       end
+    def on!      
+      set_state(1)   
+    end
 
     # Return whether the Switch is off
     #
     # @return [Boolean]
-    def off?;     get_state == :off;  end
+    def off?     
+      get_state == :off
+    end
 
     # Return whether the Switch is on
     #
     # @return [Boolean]
-    def on?;      get_state == :on;   end
+    def on?      
+      get_state == :on
+    end
 
     # Monitors the state of the Switch via polling, and yields to the block
     # given with the updated state.
@@ -111,7 +128,7 @@ module Wemote
       async ? poller : poller.join
     end
 
-    private
+    protected
 
     def get_state
       response = begin
@@ -132,24 +149,6 @@ module Wemote
 
     def client
       @client ||= Wemote::Client.new
-    end
-
-    def set_meta
-      if @port
-        response = client.get("http://#{@host}:#{@port}/setup.xml")
-        @name = response.body.match(/<friendlyName>([^<]+)<\/friendlyName>/)[1]
-      else
-        for port in 49152..49156
-          begin
-            response = nil
-            Timeout::timeout(1){ response = client.get("http://#{@host}:#{port}/setup.xml") }
-            @name = response.body.match(/<friendlyName>([^<]+)<\/friendlyName>/)[1]
-            @port = port
-            break
-          rescue Exception
-          end
-        end
-      end
     end
 
   end

--- a/lib/wemote/switch.rb
+++ b/lib/wemote/switch.rb
@@ -58,6 +58,7 @@ module Wemote
 
     def initialize(host,port=nil)
       @host, @port = host, port
+      set_meta
     end
 
     def device_type 
@@ -151,5 +152,9 @@ module Wemote
       @client ||= Wemote::Client.new
     end
 
+    def set_meta
+      response = client.get("http://#{@host}:#{@port}/setup.xml")
+      @name = response.body.match(/<friendlyName>([^<]+)<\/friendlyName>/)[1]
+    end
   end
 end

--- a/lib/wemote/version.rb
+++ b/lib/wemote/version.rb
@@ -1,3 +1,3 @@
 module Wemote
-  VERSION = "0.2.2"
+  VERSION = "0.2.3"
 end

--- a/lib/wemote/xml.rb
+++ b/lib/wemote/xml.rb
@@ -4,7 +4,8 @@ module Wemote
       xml_path = File.join(File.dirname(__FILE__),'/../../xml')
       TEMPLATES = {
         get_binary_state: File.read(File.join(xml_path,'get_binary_state.xml')),
-        set_binary_state: File.read(File.join(xml_path,'set_binary_state.xml'))
+        set_binary_state: File.read(File.join(xml_path,'set_binary_state.xml')),
+        get_insight_params: File.read(File.join(xml_path,'get_insight_params.xml'))
       }
 
       # @return [String] The required XML body for a Wemo binary state request
@@ -17,6 +18,11 @@ module Wemote
       def set_binary_state(state)
         TEMPLATES[:set_binary_state].gsub("{{1}}",state.to_s)
       end
+
+      def get_insight_params
+        TEMPLATES[:get_insight_params]
+      end
+
 
     end
   end

--- a/wemote.gemspec
+++ b/wemote.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'ssdp'
+  spec.add_dependency 'ssdp', '~> 1.1', '>= 1.1.6'
 
 end

--- a/wemote.gemspec
+++ b/wemote.gemspec
@@ -18,4 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
+
+  spec.add_dependency 'ssdp'
+
 end

--- a/xml/get_binary_state.xml
+++ b/xml/get_binary_state.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"
- s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
   <s:Body>
     <u:GetBinaryState xmlns:u="urn:Belkin:service:basicevent:1"/>
   </s:Body>

--- a/xml/get_insight_params.xml
+++ b/xml/get_insight_params.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+  <s:Body>
+    <u:GetInsightParams xmlns:u="urn:Belkin:service:insight:1"></u:GetInsightParams>
+  </s:Body>
+</s:Envelope>

--- a/xml/set_binary_state.xml
+++ b/xml/set_binary_state.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"
- s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
   <s:Body>
     <u:SetBinaryState xmlns:u="urn:Belkin:service:basicevent:1">
       <BinaryState>{{1}}</BinaryState>


### PR DESCRIPTION
Instead of maintaining the list of MAC addresses, the search is performed through the SSDP protocol.
Insight class add support to "standby?" state and can determine the power consumption of the device.